### PR TITLE
Proper handling of sumlevels 250, 252, and 254

### DIFF
--- a/aiannh_table_creation.sql
+++ b/aiannh_table_creation.sql
@@ -14,6 +14,16 @@ CREATE TABLE tiger2014.aiannh254 AS (
     WHERE comptyp = 'T'
 );
 
+-- The text concatenation stuff takes the 'R' and 'T' names, which are
+-- generally something like 'Name Reservation' and 'Name Off-Reservation Trust',
+-- and turns them into 'Name Reservation and Off-Reservation Trust'. It does
+-- this by getting the simple name (r.name), stripping it from the complex
+-- name (r.namelsad, t.namelsad) to get the other information, and
+-- concatenating all the pieces together.
+--
+-- The three parts of the query (separated by UNIONs) get areas for which there
+-- is both an 'R' and a 'T' (and combines their entries), areas for which 
+-- there is only an 'R', and areas for which there is only a 'T', in order.
 CREATE TABLE tiger2014.aiannh250 AS (
     SELECT r.aiannhce as aiannhce,
            r.aiannhns as aiannhns,
@@ -21,44 +31,102 @@ CREATE TABLE tiger2014.aiannh250 AS (
            r.name as name,
            r.name || ' ' || trim(replace(r.namelsad, r.name, '')) || ' and '
                   || trim(replace(t.namelsad, t.name, '')) as namelsad,
-           'C' as comptyp,
+           'C'::VARCHAR(1) as comptyp,
            r.aiannhr as aiannhr,
            r.funcstat as funcstat,
            r.aland + t.aland as aland,
            r.awater + t.awater as awater,
-           ST_Y(ST_Centroid(ST_Union(r.geom, t.geom))) as intptlat,
-           ST_X(ST_Centroid(ST_Union(r.geom, t.geom))) as intptlon,
-           ST_Union(r.geom, t.geom) as geom
+           ST_Y(ST_Centroid(ST_Union(r.geom, t.geom)))::VARCHAR as intptlat,
+           ST_X(ST_Centroid(ST_Union(r.geom, t.geom)))::VARCHAR as intptlon,
+           ST_Multi(ST_Union(r.geom, t.geom)) as geom
     FROM
-        (SELECT * from tiger2014.aiannh where comptyp = 'R') r,
-        (SELECT * from tiger2014.aiannh where comptyp = 'T') t
+        (SELECT * FROM tiger2014.aiannh WHERE comptyp = 'R') r,
+        (SELECT * FROM tiger2014.aiannh WHERE comptyp = 'T') t
         WHERE r.aiannhce = t.aiannhce
+
+    UNION
+
+    SELECT aiannhce, aiannhns, aiannhce as geoid, name, namelsad, comptyp, 
+           aiannhr, funcstat, aland, awater, intptlat, intptlon, geom
+    FROM tiger2014.aiannh
+    WHERE comptyp = 'R'
+    AND aiannhce NOT IN (
+        SELECT aiannhce FROM tiger2014.aiannh WHERE comptyp = 'T'
+        )
+
+    UNION
+
+    SELECT aiannhce, aiannhns, aiannhce as geoid, name, namelsad, comptyp, 
+           aiannhr, funcstat, aland, awater, intptlat, intptlon, geom
+    FROM tiger2014.aiannh
+    WHERE comptyp = 'T'
+    AND aiannhce NOT IN (
+        SELECT aiannhce FROM tiger2014.aiannh WHERE comptyp = 'R'
+        )
 );
 
 -- One row gives problems with the matching; fix that name manually
-UPDATE TABLE tiger2014.aiannh250 
+UPDATE tiger2014.aiannh250 
 SET namelsad = 'Pojoaque Pueblo and Off-Reservation Trust Land'
 WHERE name = 'Pojoaque';
 
-CREATE TABLE tiger2014.census_name_lookup_backup AS (
-    SELECT * FROM tiger2014.census_name_lookup
-);
-
+-- Remove old entries
 DELETE FROM tiger2014.census_name_lookup
 WHERE sumlevel = '250';
 
+DELETE FROM tiger2014.census_name_lookup
+WHERE sumlevel = '252';
+
+DELETE FROM tiger2014.census_name_lookup
+WHERE sumlevel = '254';
+
+-- Add the 250 sumlevel entries
 INSERT INTO tiger2014.census_name_lookup
-    SELECT aiannh.namelsad AS display_name,
-           aiannh.namelsad AS simple_name,
-           aiannh.namelsad AS prefix_match_name,
+    SELECT aiannh250.namelsad AS display_name,
+           aiannh250.namelsad AS simple_name,
+           aiannh250.namelsad AS prefix_match_name,
            '250' AS sumlevel,
-           aiannh.geoid AS geoid,
-           '25000US' || aiannh.geoid AS full_geoid,
+           aiannh250.geoid AS geoid,
+           '25000US' || aiannh250.geoid AS full_geoid,
            140 AS priority,
            b01003.b01003001 AS population,
-           aiannh.aland AS aland,
-           aiannh.awater AS awater,
-           aiannh.geom AS geom
+           aiannh250.aland AS aland,
+           aiannh250.awater AS awater,
+           aiannh250.geom AS geom
     FROM tiger2014.aiannh250
     LEFT OUTER JOIN acs2014_5yr.b01003
-    ON ('25000US' || aiannh.geoid) == b01003.geoid;
+    ON ('25000US' || aiannh250.geoid) = b01003.geoid;
+
+-- Add the 252 sumlevel entries
+INSERT INTO tiger2014.census_name_lookup
+    SELECT aiannh252.namelsad AS display_name,
+           aiannh252.namelsad AS simple_name,
+           aiannh252.namelsad AS prefix_match_name,
+           '252' AS sumlevel,
+           aiannh252.geoid AS geoid,
+           '25200US' || aiannh252.geoid AS full_geoid,
+           140 AS priority,
+           b01003.b01003001 AS population,
+           aiannh252.aland AS aland,
+           aiannh252.awater AS awater,
+           aiannh252.geom AS geom
+    FROM tiger2014.aiannh252
+    LEFT OUTER JOIN acs2014_5yr.b01003
+    ON ('25200US' || aiannh252.geoid) = b01003.geoid;
+
+-- Add the 254 sumlevel entries
+INSERT INTO tiger2014.census_name_lookup
+    SELECT aiannh254.namelsad AS display_name,
+           aiannh254.namelsad AS simple_name,
+           aiannh254.namelsad AS prefix_match_name,
+           '254' AS sumlevel,
+           aiannh254.geoid AS geoid,
+           '25400US' || aiannh254.geoid AS full_geoid,
+           140 AS priority,
+           b01003.b01003001 AS population,
+           aiannh254.aland AS aland,
+           aiannh254.awater AS awater,
+           aiannh254.geom AS geom
+    FROM tiger2014.aiannh254
+    LEFT OUTER JOIN acs2014_5yr.b01003
+    ON ('25400US' || aiannh254.geoid) = b01003.geoid;

--- a/aiannh_table_creation.sql
+++ b/aiannh_table_creation.sql
@@ -1,16 +1,16 @@
-CREATE TABLE tiger2014.aiannh252 AS (
+CREATE TABLE tiger2016.aiannh252 AS (
     SELECT gid, aiannhce, aiannhns, geoid, name, namelsad, lsad, classfp,
            comptyp, aiannhr, mtfcc, funcstat, aland, awater,
            intptlat, intptlon, geom
-    FROM tiger2014.aiannh
+    FROM tiger2016.aiannh
     WHERE comptyp = 'R'
 );
 
-CREATE TABLE tiger2014.aiannh254 AS (
+CREATE TABLE tiger2016.aiannh254 AS (
     SELECT gid, aiannhce, aiannhns, geoid, name, namelsad, lsad, classfp,
            comptyp, aiannhr, mtfcc, funcstat, aland, awater,
            intptlat, intptlon, geom
-    FROM tiger2014.aiannh
+    FROM tiger2016.aiannh
     WHERE comptyp = 'T'
 );
 
@@ -24,7 +24,7 @@ CREATE TABLE tiger2014.aiannh254 AS (
 -- The three parts of the query (separated by UNIONs) get areas for which there
 -- is both an 'R' and a 'T' (and combines their entries), areas for which 
 -- there is only an 'R', and areas for which there is only a 'T', in order.
-CREATE TABLE tiger2014.aiannh250 AS (
+CREATE TABLE tiger2016.aiannh250 AS (
     SELECT r.aiannhce as aiannhce,
            r.aiannhns as aiannhns,
            r.aiannhce as geoid,
@@ -40,48 +40,48 @@ CREATE TABLE tiger2014.aiannh250 AS (
            ST_X(ST_Centroid(ST_Union(r.geom, t.geom)))::VARCHAR as intptlon,
            ST_Multi(ST_Union(r.geom, t.geom)) as geom
     FROM
-        (SELECT * FROM tiger2014.aiannh WHERE comptyp = 'R') r,
-        (SELECT * FROM tiger2014.aiannh WHERE comptyp = 'T') t
+        (SELECT * FROM tiger2016.aiannh WHERE comptyp = 'R') r,
+        (SELECT * FROM tiger2016.aiannh WHERE comptyp = 'T') t
         WHERE r.aiannhce = t.aiannhce
 
     UNION
 
     SELECT aiannhce, aiannhns, aiannhce as geoid, name, namelsad, comptyp, 
            aiannhr, funcstat, aland, awater, intptlat, intptlon, geom
-    FROM tiger2014.aiannh
+    FROM tiger2016.aiannh
     WHERE comptyp = 'R'
     AND aiannhce NOT IN (
-        SELECT aiannhce FROM tiger2014.aiannh WHERE comptyp = 'T'
+        SELECT aiannhce FROM tiger2016.aiannh WHERE comptyp = 'T'
         )
 
     UNION
 
     SELECT aiannhce, aiannhns, aiannhce as geoid, name, namelsad, comptyp, 
            aiannhr, funcstat, aland, awater, intptlat, intptlon, geom
-    FROM tiger2014.aiannh
+    FROM tiger2016.aiannh
     WHERE comptyp = 'T'
     AND aiannhce NOT IN (
-        SELECT aiannhce FROM tiger2014.aiannh WHERE comptyp = 'R'
+        SELECT aiannhce FROM tiger2016.aiannh WHERE comptyp = 'R'
         )
 );
 
 -- One row gives problems with the matching; fix that name manually
-UPDATE tiger2014.aiannh250 
+UPDATE tiger2016.aiannh250 
 SET namelsad = 'Pojoaque Pueblo and Off-Reservation Trust Land'
 WHERE name = 'Pojoaque';
 
 -- Remove old entries
-DELETE FROM tiger2014.census_name_lookup
+DELETE FROM tiger2016.census_name_lookup
 WHERE sumlevel = '250';
 
-DELETE FROM tiger2014.census_name_lookup
+DELETE FROM tiger2016.census_name_lookup
 WHERE sumlevel = '252';
 
-DELETE FROM tiger2014.census_name_lookup
+DELETE FROM tiger2016.census_name_lookup
 WHERE sumlevel = '254';
 
 -- Add the 250 sumlevel entries
-INSERT INTO tiger2014.census_name_lookup
+INSERT INTO tiger2016.census_name_lookup
     SELECT aiannh250.namelsad AS display_name,
            aiannh250.namelsad AS simple_name,
            aiannh250.namelsad AS prefix_match_name,
@@ -93,12 +93,12 @@ INSERT INTO tiger2014.census_name_lookup
            aiannh250.aland AS aland,
            aiannh250.awater AS awater,
            aiannh250.geom AS geom
-    FROM tiger2014.aiannh250
-    LEFT OUTER JOIN acs2014_5yr.b01003
+    FROM tiger2016.aiannh250
+    LEFT OUTER JOIN acs2016_5yr.b01003
     ON ('25000US' || aiannh250.geoid) = b01003.geoid;
 
 -- Add the 252 sumlevel entries
-INSERT INTO tiger2014.census_name_lookup
+INSERT INTO tiger2016.census_name_lookup
     SELECT aiannh252.namelsad AS display_name,
            aiannh252.namelsad AS simple_name,
            aiannh252.namelsad AS prefix_match_name,
@@ -110,12 +110,12 @@ INSERT INTO tiger2014.census_name_lookup
            aiannh252.aland AS aland,
            aiannh252.awater AS awater,
            aiannh252.geom AS geom
-    FROM tiger2014.aiannh252
-    LEFT OUTER JOIN acs2014_5yr.b01003
+    FROM tiger2016.aiannh252
+    LEFT OUTER JOIN acs2016_5yr.b01003
     ON ('25200US' || aiannh252.geoid) = b01003.geoid;
 
 -- Add the 254 sumlevel entries
-INSERT INTO tiger2014.census_name_lookup
+INSERT INTO tiger2016.census_name_lookup
     SELECT aiannh254.namelsad AS display_name,
            aiannh254.namelsad AS simple_name,
            aiannh254.namelsad AS prefix_match_name,
@@ -127,6 +127,6 @@ INSERT INTO tiger2014.census_name_lookup
            aiannh254.aland AS aland,
            aiannh254.awater AS awater,
            aiannh254.geom AS geom
-    FROM tiger2014.aiannh254
-    LEFT OUTER JOIN acs2014_5yr.b01003
+    FROM tiger2016.aiannh254
+    LEFT OUTER JOIN acs2016_5yr.b01003
     ON ('25400US' || aiannh254.geoid) = b01003.geoid;

--- a/aiannh_table_creation.sql
+++ b/aiannh_table_creation.sql
@@ -1,0 +1,64 @@
+CREATE TABLE tiger2014.aiannh252 AS (
+    SELECT gid, aiannhce, aiannhns, geoid, name, namelsad, lsad, classfp,
+           comptyp, aiannhr, mtfcc, funcstat, aland, awater,
+           intptlat, intptlon, geom
+    FROM tiger2014.aiannh
+    WHERE comptyp = 'R'
+);
+
+CREATE TABLE tiger2014.aiannh254 AS (
+    SELECT gid, aiannhce, aiannhns, geoid, name, namelsad, lsad, classfp,
+           comptyp, aiannhr, mtfcc, funcstat, aland, awater,
+           intptlat, intptlon, geom
+    FROM tiger2014.aiannh
+    WHERE comptyp = 'T'
+);
+
+CREATE TABLE tiger2014.aiannh250 AS (
+    SELECT r.aiannhce as aiannhce,
+           r.aiannhns as aiannhns,
+           r.aiannhce as geoid,
+           r.name as name,
+           r.name || ' ' || trim(replace(r.namelsad, r.name, '')) || ' and '
+                  || trim(replace(t.namelsad, t.name, '')) as namelsad,
+           'C' as comptyp,
+           r.aiannhr as aiannhr,
+           r.funcstat as funcstat,
+           r.aland + t.aland as aland,
+           r.awater + t.awater as awater,
+           ST_Y(ST_Centroid(ST_Union(r.geom, t.geom))) as intptlat,
+           ST_X(ST_Centroid(ST_Union(r.geom, t.geom))) as intptlon,
+           ST_Union(r.geom, t.geom) as geom
+    FROM
+        (SELECT * from tiger2014.aiannh where comptyp = 'R') r,
+        (SELECT * from tiger2014.aiannh where comptyp = 'T') t
+        WHERE r.aiannhce = t.aiannhce
+);
+
+-- One row gives problems with the matching; fix that name manually
+UPDATE TABLE tiger2014.aiannh250 
+SET namelsad = 'Pojoaque Pueblo and Off-Reservation Trust Land'
+WHERE name = 'Pojoaque';
+
+CREATE TABLE tiger2014.census_name_lookup_backup AS (
+    SELECT * FROM tiger2014.census_name_lookup
+);
+
+DELETE FROM tiger2014.census_name_lookup
+WHERE sumlevel = '250';
+
+INSERT INTO tiger2014.census_name_lookup
+    SELECT aiannh.namelsad AS display_name,
+           aiannh.namelsad AS simple_name,
+           aiannh.namelsad AS prefix_match_name,
+           '250' AS sumlevel,
+           aiannh.geoid AS geoid,
+           '25000US' || aiannh.geoid AS full_geoid,
+           140 AS priority,
+           b01003.b01003001 AS population,
+           aiannh.aland AS aland,
+           aiannh.awater AS awater,
+           aiannh.geom AS geom
+    FROM tiger2014.aiannh250
+    LEFT OUTER JOIN acs2014_5yr.b01003
+    ON ('25000US' || aiannh.geoid) == b01003.geoid;


### PR DESCRIPTION
See censusreporter/censusreporter#34 for an explanation of the problem this solves.

In order for these geographies to be handled correctly, three things are necessary:
- The geographies have to appear in tiger2014.census_name_lookup with information (namely, geoids) that do not contradict the ACS geoheader table.
- The API has to return these geographies.
- Search results and autocomplete have to include these geographies.

This fixes the first of the three parts. This script creates pseudo-tiger tables for sumlevels 250, 252, and 254 so that the geoids correctly correspond to acs2014_5yr.geoheader. It then inserts (replaces if some already exist) rows into tiger2014.census_name_lookup for these sumlevels, so that they appear in API calls, search results, and autosuggest.
