### PR TITLE
Updated the file path for acs2009_5yr

### DIFF
--- a/02_download_acs_2009_5yr.sh
+++ b/02_download_acs_2009_5yr.sh
@@ -7,18 +7,15 @@ sudo chown ubuntu /mnt/tmp
 # Grab the 2009 ACS 5 year
 cd /mnt/tmp
 mkdir -p acs2009_5yr/group{1,2}
-cd acs2009_5yr/group1
 sudo apt-get -y install unzip aria2
 aria2c --dir=/mnt/tmp/acs2009_5yr --max-connection-per-server=5 --force-sequential=true \
     "http://www2.census.gov/acs2009_5yr/summaryfile/2005-2009_ACSSF_All_In_2_Giant_Files(Experienced-Users-Only)/All_Geographies_Not_Tracts_Block_Groups.zip" \
     "http://www2.census.gov/acs2009_5yr/summaryfile/2005-2009_ACSSF_All_In_2_Giant_Files(Experienced-Users-Only)/Tracts_Block_Groups_Only.zip" \
     "http://www2.census.gov/acs2009_5yr/summaryfile/UserTools/Sequence_Number_and_Table_Number_Lookup.txt"
-unzip -q All_Geographies_Not_Tracts_Block_Groups.zip
+unzip -q All_Geographies_Not_Tracts_Block_Groups.zip -d ./tmp
 # This zip contains per-state zips, so unzip those too
-for i in *_All_Geographies_Not_Tracts_Block_Groups.zip; do unzip -q $i; done
-cd ../group2
-unzip -q Tracts_Block_Groups_Only.zip
-cd ..
+for i in ./tmp/*_All_Geographies_Not_Tracts_Block_Groups.zip; do unzip -q -d ./group1 $i; done
+unzip -q Tracts_Block_Groups_Only.zip -d ./group2
 
 # Let the Postgres user access this data
 chmod 777 /mnt/tmp/acs2009_5yr/group1 /mnt/tmp/acs2009_5yr/group2


### PR DESCRIPTION
Corrected the extraction behavior to accurately extract at the correct location. 
This updated bash script should unzip All_Geographies_Not_Tracts_Block_Groups.zip into a tmp path, and then extract the files in the tmp path to group1 as well as unzipping Tracts_Block_Groups_Only.zip to group2

Please note that https://github.com/censusreporter/census-postgres-scripts/issues/15 might be encountered.