### PR TITLE
Proposed fix for jam values in table based files

### DIFF
--- a/table_based/02_download_acs_2021_5yr.sh
+++ b/table_based/02_download_acs_2021_5yr.sh
@@ -13,3 +13,14 @@ curl -L "https://census-backup.b-cdn.net/programs-surveys/acs/summary_file/2021/
      -o ${DATA_DIR}/ACS20215YR_Table_Shells.txt
 
 unzip -q ${DATA_DIR}/AllTables.zip
+
+# table-based files have "jam values" which should not be loaded into our database
+JAM_VALUES="-222222222|-333333333|-555555555|-666666666|-888888888|-999999999"
+TMP_DIR="${DATA_DIR}/tmp"
+mkdir $TMP_DIR
+for i in `ls ${DATA_DIR}/*.dat`; do
+    file_name=`basename $i`
+    sed -E "s/${JAM_VALUES}//g" $i > "${TMP_DIR}/${file_name}"
+    mv "${TMP_DIR}/${file_name}" $i
+done;
+rmdir $TMP_DIR

--- a/table_based/02_download_acs_2022_1yr.sh
+++ b/table_based/02_download_acs_2022_1yr.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 DATA_DIR=/home/ubuntu/data/acs2022_1yr
 DATA_SERVER="https://census-backup.b-cdn.net"
+
 mkdir -p $DATA_DIR
 sudo apt-get -y install unzip
 
@@ -10,3 +11,14 @@ curl -L "${DATA_SERVER}/programs-surveys/acs/summary_file/2022/table-based-SF/do
 curl -L "${DATA_SERVER}/programs-surveys/acs/summary_file/2022/table-based-SF/documentation/ACS20221YR_Table_Shells.txt" -o ${DATA_DIR}/ACS20221YR_Table_Shells.txt
 
 unzip -q -j -d $DATA_DIR $DATA_DIR/All_Tables.zip
+
+# table-based files have "jam values" which should not be loaded into our database
+JAM_VALUES="-222222222|-333333333|-555555555|-666666666|-888888888|-999999999"
+TMP_DIR="${DATA_DIR}/tmp"
+mkdir $TMP_DIR
+for i in `ls ${DATA_DIR}/*.dat`; do
+    file_name=`basename $i`
+    sed -E "s/${JAM_VALUES}//g" $i > "${TMP_DIR}/${file_name}"
+    mv "${TMP_DIR}/${file_name}" $i
+done;
+rmdir $TMP_DIR


### PR DESCRIPTION
I added a chunk of script at the bottom of the two table-based downloader files to strip out the specified "jam values" from data files, so that we don't inadvertently load spurious values next time we run these processes.

I've tested the code separate from actually loading the files into Postgres, but I figured it deserved more eyes, so submitting as a PR for @iandees review.